### PR TITLE
Task queue and other cleanups

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,4 +7,4 @@ COPY README.md /app
 COPY ./src /app/src
 RUN poetry config virtualenvs.create false
 RUN poetry install --only main
-ENTRYPOINT ["poetry", "run", "python", "-m", "pudl_output_differ.main"]
+ENTRYPOINT ["poetry", "run", "diff"] 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,13 @@
 FROM python:3.10-buster
 RUN pip install poetry==1.6
 
+# TODO(rousik): Presumably, when we run this tool, we will want to
+# either mount remote paths as "local" directories, or cache the remote
+# files locally using plentiful storage.
+
+# --cache-dir argument can be used to control where things are cached.
+
+
 WORKDIR /app
 COPY pyproject.toml poetry.lock /app
 COPY README.md /app

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,9 @@ authors = ["Jan Rous <rousik@gmail.com>"]
 readme = "README.md"
 packages = [{include = "pudl_output_differ", from = "src"}]
 
+[tool.poetry.scripts]
+diff = "pudl_output_differ.cli:main"
+
 [tool.poetry.dependencies]
 python = "^3.10"
 pydantic = "^2.3.0"

--- a/src/pudl_output_differ/cli.py
+++ b/src/pudl_output_differ/cli.py
@@ -18,13 +18,15 @@ import tempfile
 import markdown
 
 from pudl_output_differ.files import DirectoryAnalyzer, is_remote
-from pudl_output_differ.types import TaskQueue
+from pudl_output_differ.task_queue import TaskQueue
 from opentelemetry.sdk.resources import SERVICE_NAME, Resource
 from opentelemetry.sdk.trace.export import BatchSpanProcessor
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
 from opentelemetry import trace
 from mdx_gfm import GithubFlavoredMarkdownExtension
+
+from pudl_output_differ.types import ObjectPath
 
 logger = logging.getLogger(__name__)
 tracer = trace.get_tracer(__name__)
@@ -161,7 +163,7 @@ def main() -> int:
 
         task_queue.put(
             DirectoryAnalyzer(
-                object_path=[],
+                object_path=ObjectPath(),
                 left_path=lpath,
                 right_path=rpath,
                 local_cache_root=args.cache_dir,

--- a/src/pudl_output_differ/cli.py
+++ b/src/pudl_output_differ/cli.py
@@ -170,30 +170,11 @@ def main() -> int:
                 filename_filter=args.filename_filter,
             )
         )
-        reports = 0
-        nonempty_reports = 0
-        for analysis in task_queue.iter_analyses(
-            catch_exceptions=args.catch_exceptions
-        ):
-            reports += 1
-            # TODO(rousik): it would be good if AnalysisReport contained metadata
-            # identifyng the analyzer that produced it. Perhaps we could use
-            # wrapper that will contain both the analysis, as well as the analyzer
-            # metadata, e.g.:
-            # - object_path
-            # - instance that produced it (config)
-            # - possible runtime exception information (so that we can distinguish)
-            # Analysis itself could have severity (ERROR, WARNING) to indicate
-            # whether the problem is serious or not.
-            if analysis.markdown:
-                nonempty_reports += 1
-                print(analysis.title)
-                print(analysis.markdown)
-                print()
-        logger.info(f"Total {reports} reports, with {nonempty_reports} nonempty.")
+        task_queue.run()
+        task_queue.wait()
 
     if args.html_report:
-        md = task_queue.to_markdown(catch_exceptions=True)
+        md = task_queue.to_markdown()
         with open(args.html_report, "w") as f:
             f.write(MARKDOWN_CSS_STYLE)
             f.write('<article class="markdown-body">')

--- a/src/pudl_output_differ/files.py
+++ b/src/pudl_output_differ/files.py
@@ -82,17 +82,19 @@ class DirectoryAnalyzer(Analyzer):
         # fs to detrmine local path only when needed.
         return f.name
 
-    # TODO(rousik): passing parents this way is a bit clunky, but acceptable.
-    @tracer.start_as_current_span(name="DirectoryAnalyzer")
     def execute(self, task_queue: TaskQueueInterface) -> AnalysisReport:
         """Computes diff between two output directories.
 
         Files on the left and right are compared for presence, children
         are deeper-layer analyzers for specific file types that are supported.
         """
-        sp = trace.get_current_span()
-        sp.set_attribute("left_path", self.left_path)
-        sp.set_attribute("right_path", self.right_path)
+        trace.get_current_span().set_attributes(
+            {
+                "left_path": self.left_path,
+                "right_path": self.right_path,
+            }
+        )
+
         lfs = self.get_files(self.left_path)
         rfs = self.get_files(self.right_path)
 

--- a/src/pudl_output_differ/files.py
+++ b/src/pudl_output_differ/files.py
@@ -9,7 +9,7 @@ import fsspec
 from pudl_output_differ.sqlite import Database, SQLiteAnalyzer
 
 from pudl_output_differ.types import (
-    AnalysisReport, Analyzer, KeySetDiff, TaskQueue
+    AnalysisReport, Analyzer, KeySetDiff, TaskQueueInterface
 )
 
 logger = logging.getLogger(__name__)
@@ -84,7 +84,7 @@ class DirectoryAnalyzer(Analyzer):
 
     # TODO(rousik): passing parents this way is a bit clunky, but acceptable.
     @tracer.start_as_current_span(name="DirectoryAnalyzer")
-    def execute(self, task_queue: TaskQueue) -> AnalysisReport:
+    def execute(self, task_queue: TaskQueueInterface) -> AnalysisReport:
         """Computes diff between two output directories.
 
         Files on the left and right are compared for presence, children
@@ -106,8 +106,8 @@ class DirectoryAnalyzer(Analyzer):
 
                 task_queue.put(
                     SQLiteAnalyzer(
-                        object_path = [Database(name=shared_file)],
-                        db_name = shared_file,
+                        object_path=self.object_path.extend(Database(name=shared_file)),
+                        db_name=shared_file,
                         left_db_path=left_path,
                         right_db_path=right_path,
                     )
@@ -115,7 +115,7 @@ class DirectoryAnalyzer(Analyzer):
             # TODO(rousik): other file formats are: json, parquet, yml.
 
         return AnalysisReport(
-            object_path = [],
-            title = "# Files",
-            markdown = file_diff.markdown(long_format=True),
+            object_path=self.object_path,
+            title= "# Files",
+            markdown=file_diff.markdown(long_format=True),
         )

--- a/src/pudl_output_differ/parquet.py
+++ b/src/pudl_output_differ/parquet.py
@@ -1,65 +1,65 @@
-"""Module for comparing contents of parquet files."""
+# """Module for comparing contents of parquet files."""
 
-import logging
-from pudl_output_differ.sqlite import RowCountDiff
-from pudl_output_differ.types import DiffEvaluatorBase, DiffTreeNode, KeySetDiff, TaskQueue
-import pyarrow.parquet as pq
-
-
-logger = logging.getLogger(__name__)
+# import logging
+# from pudl_output_differ.sqlite import RowCountDiff
+# from pudl_output_differ.types import DiffEvaluatorBase, DiffTreeNode, KeySetDiff, TaskQueue
+# import pyarrow.parquet as pq
 
 
-class ParquetEvaluator(DiffEvaluatorBase):
-    left_path: str
-    right_path: str
+# logger = logging.getLogger(__name__)
 
 
-    def get_columns(self, schema: pq.ParquetSchema)-> list[str]:
-        """Return list containing column_name::column_type."""
-        ret = []
-        for i in len(schema.names):
-            ret.append(
-                schema.column(i).name + "::" + schema.column(i).logical_type.type
-            )
-        return ret
+# class ParquetEvaluator(DiffEvaluatorBase):
+#     left_path: str
+#     right_path: str
+
+
+#     def get_columns(self, schema: pq.ParquetSchema)-> list[str]:
+#         """Return list containing column_name::column_type."""
+#         ret = []
+#         for i in len(schema.names):
+#             ret.append(
+#                 schema.column(i).name + "::" + schema.column(i).logical_type.type
+#             )
+#         return ret
     
-    def execute(self, task_queue: TaskQueue) -> list[DiffTreeNode]:
-        """Compare two parquet files."""
-        diffs = []
-        # lfs, lpath = fsspec.core.url_to_fs(self.left_path)
-        # rfs, rpath = fsspec.open(self.right_path)
+#     def execute(self, task_queue: TaskQueue) -> list[DiffTreeNode]:
+#         """Compare two parquet files."""
+#         diffs = []
+#         # lfs, lpath = fsspec.core.url_to_fs(self.left_path)
+#         # rfs, rpath = fsspec.open(self.right_path)
         
-        lmeta = pq.read_metadata(self.left_path)
-        rmeta = pq.read_metadata(self.right_path)
-        if not lmeta.schema.equals(rmeta.schema):
-            logger.info("Parquet schemas are different.")
-            diffs.append(
-                self.parent_node.add_child(
-                    DiffTreeNode(
-                        name="ParquetSchema",
-                        diff=KeySetDiff.from_sets(
-                            set(self.get_columns(lmeta.schema)),
-                            set(self.get_columns(rmeta.schema)),
-                            entity="columns",
-                        )
-                    )
-                )
-            )
-        # Now, go on to compare the metadata more broadly.
-        if not lmeta.equals(rmeta):
-            logger.info("Parquet metadata are different.")
-            logger.info(f"Left metadata: {lmeta}")
-            logger.info(f"Right metadata: {rmeta}")
-            if lmeta.num_rows != rmeta.num_rows:
-                logger.info("Number of rows are different.")
-                diffs.append(
-                    self.parent_node.add_child(
-                        DiffTreeNode(
-                            name="ParquetNumRows",
-                            diff=RowCountDiff(
-                                left_rows=lmeta.num_rows,
-                                right_rows=rmeta.num_rows)
-                        )
-                    )
-                )
-        return diffs
+#         lmeta = pq.read_metadata(self.left_path)
+#         rmeta = pq.read_metadata(self.right_path)
+#         if not lmeta.schema.equals(rmeta.schema):
+#             logger.info("Parquet schemas are different.")
+#             diffs.append(
+#                 self.parent_node.add_child(
+#                     DiffTreeNode(
+#                         name="ParquetSchema",
+#                         diff=KeySetDiff.from_sets(
+#                             set(self.get_columns(lmeta.schema)),
+#                             set(self.get_columns(rmeta.schema)),
+#                             entity="columns",
+#                         )
+#                     )
+#                 )
+#             )
+#         # Now, go on to compare the metadata more broadly.
+#         if not lmeta.equals(rmeta):
+#             logger.info("Parquet metadata are different.")
+#             logger.info(f"Left metadata: {lmeta}")
+#             logger.info(f"Right metadata: {rmeta}")
+#             if lmeta.num_rows != rmeta.num_rows:
+#                 logger.info("Number of rows are different.")
+#                 diffs.append(
+#                     self.parent_node.add_child(
+#                         DiffTreeNode(
+#                             name="ParquetNumRows",
+#                             diff=RowCountDiff(
+#                                 left_rows=lmeta.num_rows,
+#                                 right_rows=rmeta.num_rows)
+#                         )
+#                     )
+#                 )
+#         return diffs

--- a/src/pudl_output_differ/sqlite.py
+++ b/src/pudl_output_differ/sqlite.py
@@ -86,11 +86,10 @@ class SQLiteAnalyzer(Analyzer):
             return True
         return table_name in self.settings.sqlite_tables_only
 
-    @tracer.start_as_current_span(name="SQLiteAnalyzer.execute")
     def execute(self, task_queue: TaskQueueInterface) -> AnalysisReport:
         """Analyze tables and their schemas."""
-        sp = trace.get_current_span()
-        sp.set_attribute("db_name", self.db_name)
+        trace.get_current_span().set_attribute("db_name", self.db_name)
+
         ldb = create_engine(f"sqlite:///{self.left_db_path}")
         rdb = create_engine(f"sqlite:///{self.right_db_path}")
 
@@ -242,7 +241,6 @@ class TableAnalyzer(Analyzer):
             markdown=md.getvalue(),
         )
 
-    @tracer.start_as_current_span(name="TableAnalyzer.execute")
     def execute(self, task_queue: TaskQueueInterface) -> AnalysisReport:
         """Analyze tables and their schemas."""
         sp = trace.get_current_span()

--- a/src/pudl_output_differ/task_queue.py
+++ b/src/pudl_output_differ/task_queue.py
@@ -3,31 +3,52 @@ Implementation of the TaskQueue class that handles parallel execution
 of the outstanding analyses.
 """
 
-from asyncio import ALL_COMPLETED
+from collections import Counter
+from time import sleep
+from enum import IntEnum
 from io import StringIO
 import logging
 import threading
 import concurrent.futures
 import traceback
-from typing import Iterator
+from uuid import uuid1
+
+from pydantic import UUID1, BaseModel, Field
+from pudl_output_differ.sqlite import Database
 
 from pudl_output_differ.types import AnalysisReport, Analyzer, ObjectPath, ReportSeverity
 
 from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
-from opentelemetry import context
+from opentelemetry import context, trace
 
 
 logger = logging.getLogger(__name__)
+tracer = trace.get_tracer(__name__)
 
 
+class ExecutionState(IntEnum):
+    """Encodes possible state of Analysis in the queue.
+    
+    Each analysis will start as PENDING, once it is chosen to be executed,
+    it moves to RUNNING and once it is completed, it can be either COMPLETED
+    or FAILED.
+    """
+    PENDING = 0 
+    RUNNING = 1
+    COMPLETED = 2
+    FAILED = 3
 
-class AnalysisMetadata:
+class AnalysisMetadata(BaseModel):
     """Represents the analysis that should be run."""
 
+    id: UUID1 = Field(default_factory=uuid1)
     object_path: ObjectPath
     analyzer: Analyzer
-
-
+    report: AnalysisReport | None = None
+    state: ExecutionState = ExecutionState.PENDING
+    # TODO(rousik): perhaps add field for the traceback of the exception
+    # or the exception itself (?); perhaps embedding this in the report is
+    # okay also.
 
 
 class TaskQueue:
@@ -42,88 +63,145 @@ class TaskQueue:
         # We could also indicate which tables are possibly expensive
         # in the differ configuration, which will eliminate the need
         # for dynamically estimating the cost.
-
-        self.executor = concurrent.futures.ThreadPoolExecutor(max_workers=max_workers)
+        self.max_workers = max_workers
+        self.executor = concurrent.futures.ThreadPoolExecutor()
         self._lock = threading.Lock()
-        self.analyses: dict[concurrent.futures.Future, Analyzer] = {}
+        self._cond = threading.Condition(self._lock)
+        self.pending_tasks: dict[UUID1, AnalysisMetadata] = {}
+        self.inflight_tasks: dict[UUID1, AnalysisMetadata] = {}
+        self.completed_tasks: dict[UUID1, AnalysisMetadata] = {}
+        self.runners: list[concurrent.futures.Future] = []
         self.trace_carrier = {}
+        self.max_db_concurrency = 1
         TraceContextTextMapPropagator().inject(self.trace_carrier)
 
-    def run_analysis(self) -> AnalysisReport:
-        """Picks analysis to run and executes it."""
+    def has_pending_tasks(self):
+        """Returns if any tasks are pending execution."""
+        with self._lock:
+            return len(self.pending_tasks) > 0
+        
+    def get_next_task(self) -> AnalysisMetadata | None:
+        """Returns next pending analysis to run.
+        
+        Returns None if there's no task to run. This could mean the queue
+        is empty, or maybe that all tasks have constraints that can't be 
+        currently met.
+        """
+        with self._lock:
+            if not self.pending_tasks:
+                return None
+            
+            # TODO(rousik): pick next task such there's only single RUNNING
+            # task that has specific Database() instance in its path.
+
+            db_open_count: Counter = Counter()
+            for am in self.inflight_tasks.values():
+                db: Database | None = am.object_path.get_first(Database) # type: ignore
+                if db is None:
+                    continue
+                db_open_count.update(db.name)
+
+            for am in self.pending_tasks.values():
+                db: Database | None = am.object_path.get_first(Database) # type: ignore
+                if db is not None and db_open_count.get(db.name, 0) >= self.max_db_concurrency:
+                    # This task is currently not viable for scheduling.
+                    continue
+                
+                # This task can be scheduled, move it to in-flight, change status and return.
+                am.state = ExecutionState.RUNNING
+                del self.pending_tasks[am.id]
+                self.inflight_tasks[am.id] = am
+                return am
+        
+            return None
+    
+    def analysis_runner(self) -> None:
+        """Runs the analyses in the queue until there are no more pending tasks.
+
+        This method is expected to be run multiple times in parallel and process
+        the analysis queue until it is empty. It will also collect reports and
+        possible runtime exceptions.
+        """
+
         # TODO(rousik): Implement this, this can contain the exception catching code
         # once and for all. Resulting analyses can be put in the output queue.
         # Perhaps instead of using ThreadpoolExecutor, we can simply launch bunch
         # of these runners in parallel based on max_workers flag.
-        ...
+        token = None
+        if self.trace_carrier:
+            ctx = TraceContextTextMapPropagator().extract(carrier=self.trace_carrier)
+            token = context.attach(ctx)
+        try:
+            # TODO(rousik): wrap this in spans to make it work well.
+            while self.has_pending_tasks():
+                cur_task = self.get_next_task()
+                if cur_task is None:
+                    logger.debug("No tasks to run, waiting for more...")
+                    # We should ideally wait for when any of the in-flight tasks
+                    # complete and then recalculate. But waiting for 1s and eagerly
+                    # trying again is a reasonable workaround.
+                    sleep(1)
+                    continue
+
+                analyzer_name = cur_task.analyzer.__class__.__name__
+                with tracer.start_as_current_span(f"{analyzer_name}.execute") as sp:
+                    sp.set_attribute("object_path", str(cur_task.object_path))
+                    try:
+                        cur_task.report = cur_task.analyzer.execute(self)
+                        cur_task.state = ExecutionState.COMPLETED
+                    except Exception:
+                        cur_task.state = ExecutionState.FAILED
+                        # Umph, the analyzer failed; log the problem and make synthetic report.
+                        error_title = f"{cur_task.analyzer.__class__.__name__} failed on {next_analysis.object_path}"
+                        cur_task.report = AnalysisReport(
+                            object_path=cur_task.object_path,
+                            title=f"## {error_title}",
+                            markdown=f"\n```\n{traceback.format_exc()}\n```\n",
+                            severity=ReportSeverity.EXCEPTION,
+                        )
+                # Move the analysis to completed state.
+                with self._lock:
+                    self.completed_tasks[cur_task.id] = cur_task
+                    del self.inflight_tasks[cur_task.id]
+
+                    # The following print-as-they-become available should be a debug feature.
+                    # TODO(rousik): It should be possible to turn this functionality off.
+                with self._lock:
+                    if cur_task.report and cur_task.report.has_changes():
+                        print(cur_task.report.title)
+                        print(cur_task.report.markdown)
+
+            logger.info("Queue has no more pending tasks, terminating this runner.")
+        finally:
+            if token is not None:
+                context.detach(token)
+
+    def run(self):
+        """Kicks off analysis_runners in the thread pool."""
+        for i in range(self.max_workers):
+            self.runners.append(self.executor.submit(self.analysis_runner))
 
     def put(self, analyzer: Analyzer):
         """Add evaluator to the execution queue."""
         with self._lock:
-            # TODO(rousik): here we should decide on how to handle
-            # big tasks that need to be run in isolation, e.g. 
-            # analyis of very large sql tables.
-            def traced_execute():
-                if self.trace_carrier:
-                    ctx = TraceContextTextMapPropagator().extract(carrier=self.trace_carrier)
-                    token = context.attach(ctx)
-                    try:
-                        logger.debug(f"Executing {analyzer.__class__.__name__} with configuration: {analyzer}")
-                        return analyzer.execute(self)
-                    finally:
-                        context.detach(token)
-                else:
-                    return analyzer.execute(self)
-
-            fut = self.executor.submit(traced_execute)
-            self.analyses[fut] = analyzer
-            # TODO(rousik): perhaps we can have a better way to associate
-            # reports with the analyzer metadata and other info.
-
-    def iter_analyses(self, catch_exceptions:bool=True) -> Iterator[AnalysisReport]:        
-        keys_seen = set()
-        while True:
-            remaining_futures = set(self.analyses.keys()).difference(keys_seen)
-            if not remaining_futures:
-                return
-            keys_seen.update(remaining_futures)
-            for fut in concurrent.futures.as_completed(remaining_futures):
-                analyzer = self.analyses[fut]
-                try:
-                    yield fut.result()
-                except Exception as e:
-                    error_title = f"{analyzer.__class__.__name__} failed on {analyzer.object_path}"
-                    if not catch_exceptions:
-                        raise RuntimeError(error_title) from e
-                    logger.error(f"Analyzer {analyzer.__class__.__name__} failed on {analyzer.object_path}: {repr(e)}")
-
-                    # Otherwise, render exception as markdown.
-                    yield AnalysisReport(
-                        object_path=analyzer.object_path,
-                        title=f"## {error_title}",
-                        markdown=f"\n```\n{traceback.format_exc()}\n```\n",
-                        severity=ReportSeverity.EXCEPTION,
-                    )
-     
+            am = AnalysisMetadata(
+                object_path=analyzer.object_path,
+                analyzer=analyzer,
+            )
+            self.pending_tasks[am.id] = am
+            # Do we need to kick of analyzer threads/tasks?
+    
     def wait(self):
-        """Waits until all tasks are done."""
-        concurrent.futures.wait(self.analyses.keys(), return_when=ALL_COMPLETED)
+        """Awaits until all tasks are completed."""
+        concurrent.futures.wait(self.runners, return_when="ALL_COMPLETED")        
 
-    def to_markdown(self, catch_exceptions: bool = True) -> str:
-        reports = list(self.iter_analyses(catch_exceptions=catch_exceptions))
-        reports.sort(key=lambda r: r.object_path)
+    def to_markdown(self) -> str:
+        """Convert all reports to markdown, sorting them by their object_paths."""
+        assert len(self.pending_tasks) + len(self.inflight_tasks) == 0
+
         md = StringIO()
-        for rep in reports:
-            if rep.has_changes():
-                md.write(f"\n{rep.title}\n")
-                md.write(rep.markdown)
+        for task in sorted(self.completed_tasks.values(), key=lambda t: t.object_path):
+            if task.report and task.report.has_changes():
+                md.write(f"\n{task.report.title}\n")
+                md.write(task.report.markdown)
         return md.getvalue()
-     
-    def get_analyses(self, catch_exceptions:bool = True) -> list[AnalysisReport]:
-        """Retrieve all analysis reports.
-
-        This is expected to be called only after wait().
-        
-        """
-        self.wait()
-        return list(self.iter_analyses(catch_exceptions=catch_exceptions))

--- a/src/pudl_output_differ/task_queue.py
+++ b/src/pudl_output_differ/task_queue.py
@@ -1,0 +1,129 @@
+"""
+Implementation of the TaskQueue class that handles parallel execution
+of the outstanding analyses.
+"""
+
+from asyncio import ALL_COMPLETED
+from io import StringIO
+import logging
+import threading
+import concurrent.futures
+import traceback
+from typing import Iterator
+
+from pudl_output_differ.types import AnalysisReport, Analyzer, ObjectPath, ReportSeverity
+
+from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
+from opentelemetry import context
+
+
+logger = logging.getLogger(__name__)
+
+
+
+class AnalysisMetadata:
+    """Represents the analysis that should be run."""
+
+    object_path: ObjectPath
+    analyzer: Analyzer
+
+
+
+
+class TaskQueue:
+    """Thread pool backed executor for diff evaluation."""
+    def __init__(self, max_workers: int = 1, no_threadpool: bool = False):
+        # TODO(rousik): when dealing with sqlite tables, we could consider
+        # estimating their payload size and assigning cost to each task
+        # to ensure that we do not overload the worker with memory
+        # pressure.
+        # For now, using single worker (slower but safer) is a reasonable
+        # workaround or initial strategy.
+        # We could also indicate which tables are possibly expensive
+        # in the differ configuration, which will eliminate the need
+        # for dynamically estimating the cost.
+
+        self.executor = concurrent.futures.ThreadPoolExecutor(max_workers=max_workers)
+        self._lock = threading.Lock()
+        self.analyses: dict[concurrent.futures.Future, Analyzer] = {}
+        self.trace_carrier = {}
+        TraceContextTextMapPropagator().inject(self.trace_carrier)
+
+    def run_analysis(self) -> AnalysisReport:
+        """Picks analysis to run and executes it."""
+        # TODO(rousik): Implement this, this can contain the exception catching code
+        # once and for all. Resulting analyses can be put in the output queue.
+        # Perhaps instead of using ThreadpoolExecutor, we can simply launch bunch
+        # of these runners in parallel based on max_workers flag.
+        ...
+
+    def put(self, analyzer: Analyzer):
+        """Add evaluator to the execution queue."""
+        with self._lock:
+            # TODO(rousik): here we should decide on how to handle
+            # big tasks that need to be run in isolation, e.g. 
+            # analyis of very large sql tables.
+            def traced_execute():
+                if self.trace_carrier:
+                    ctx = TraceContextTextMapPropagator().extract(carrier=self.trace_carrier)
+                    token = context.attach(ctx)
+                    try:
+                        logger.debug(f"Executing {analyzer.__class__.__name__} with configuration: {analyzer}")
+                        return analyzer.execute(self)
+                    finally:
+                        context.detach(token)
+                else:
+                    return analyzer.execute(self)
+
+            fut = self.executor.submit(traced_execute)
+            self.analyses[fut] = analyzer
+            # TODO(rousik): perhaps we can have a better way to associate
+            # reports with the analyzer metadata and other info.
+
+    def iter_analyses(self, catch_exceptions:bool=True) -> Iterator[AnalysisReport]:        
+        keys_seen = set()
+        while True:
+            remaining_futures = set(self.analyses.keys()).difference(keys_seen)
+            if not remaining_futures:
+                return
+            keys_seen.update(remaining_futures)
+            for fut in concurrent.futures.as_completed(remaining_futures):
+                analyzer = self.analyses[fut]
+                try:
+                    yield fut.result()
+                except Exception as e:
+                    error_title = f"{analyzer.__class__.__name__} failed on {analyzer.object_path}"
+                    if not catch_exceptions:
+                        raise RuntimeError(error_title) from e
+                    logger.error(f"Analyzer {analyzer.__class__.__name__} failed on {analyzer.object_path}: {repr(e)}")
+
+                    # Otherwise, render exception as markdown.
+                    yield AnalysisReport(
+                        object_path=analyzer.object_path,
+                        title=f"## {error_title}",
+                        markdown=f"\n```\n{traceback.format_exc()}\n```\n",
+                        severity=ReportSeverity.EXCEPTION,
+                    )
+     
+    def wait(self):
+        """Waits until all tasks are done."""
+        concurrent.futures.wait(self.analyses.keys(), return_when=ALL_COMPLETED)
+
+    def to_markdown(self, catch_exceptions: bool = True) -> str:
+        reports = list(self.iter_analyses(catch_exceptions=catch_exceptions))
+        reports.sort(key=lambda r: r.object_path)
+        md = StringIO()
+        for rep in reports:
+            if rep.has_changes():
+                md.write(f"\n{rep.title}\n")
+                md.write(rep.markdown)
+        return md.getvalue()
+     
+    def get_analyses(self, catch_exceptions:bool = True) -> list[AnalysisReport]:
+        """Retrieve all analysis reports.
+
+        This is expected to be called only after wait().
+        
+        """
+        self.wait()
+        return list(self.iter_analyses(catch_exceptions=catch_exceptions))

--- a/src/pudl_output_differ/types.py
+++ b/src/pudl_output_differ/types.py
@@ -72,6 +72,14 @@ class ObjectPath(BaseModel):
         """Returns object path represented as a string."""
         return "/".join(str(p) for p in self.path)
     
+    def get_first(self, cls: type[TypeDef]) -> TypeDef | None:
+        """Retrieves first node of the given type from the path."""
+        for node in self.path:
+            if isinstance(node, cls):
+                return node
+        return None
+    
+    
     @staticmethod
     def from_nodes(*nodes: TypeDef) -> "ObjectPath":
         """Converts list of TypeDef instances to a path instance."""

--- a/tests/sqlite_test.py
+++ b/tests/sqlite_test.py
@@ -147,6 +147,7 @@ class TestSQLiteAnalyzer(unittest.TestCase):
                 right_db_path=right.name,
             )
         )
+        task_queue.run()
         self.assertEqual(
             dedent(
                 """

--- a/tests/types_test.py
+++ b/tests/types_test.py
@@ -1,0 +1,43 @@
+import unittest
+ 
+from pudl_output_differ import types
+
+
+class MyType(types.TypeDef):
+    """Test type."""
+    a: str
+    b: str
+    def __str__(self):
+        return f"MyType({self.a}:{self.b})"
+    
+
+class Zeta(types.TypeDef):
+    value: int
+    def __str__(self):
+        return f"Zeta({self.value})"
+    
+
+class TestObjectPath(unittest.TestCase):
+
+    def test_extend_and_sort(self):
+        p1 = types.ObjectPath.from_nodes(
+            MyType(a="foo", b="bar"),
+            Zeta(value=10),
+        )
+        self.assertEqual("MyType(foo:bar)/Zeta(10)", str(p1))
+
+        # new instances with same values should be equal
+        self.assertEqual(p1.extend(Zeta(value=3)), p1.extend(Zeta(value=3)))
+
+        p20 = p1.extend(Zeta(value=20))
+        p15 = p1.extend(Zeta(value=15))
+        self.assertEqual("MyType(foo:bar)/Zeta(10)/Zeta(15)", str(p15))
+        self.assertEqual("MyType(foo:bar)/Zeta(10)/Zeta(20)", str(p20))
+        self.assertLess(p15, p20)
+        self.assertLess(p1, p15)
+        self.assertLess(p1, p20)
+
+        self.assertLess(p15.extend(Zeta(value=10)), p20.extend(Zeta(value=5)))
+        self.assertLess(p15.extend(Zeta(value=10)), p20.extend(Zeta(value=20)))
+
+        # p15 < p20, so anything appended to p15 should be less than anything appended to p20.


### PR DESCRIPTION
This change introduces some cleanups, including:
- creating separate model for object path, encapsulating its features and behaviors
- adding support for running diff tool via poetry command 
- move task queue into `task_queue.py` module, and rework its internal to use runners on n-threads. This way, we can manage task order and choose priority, or enforce constraints
- for now, only permit one task per sqlite database to avoid collisions when accessing the underlying file
- add some extra tests